### PR TITLE
Add packages, url, and author to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 from setuptools import setup
 
 setup(name='gym_RLcourse',
-      version='0.0.1',
-     install_requires=['gym']
+      author='Ayca Özcelikkale',
+      url='https://github.com/ozayca/gym-RLcourse',
+      packages=["gym_RLcourse"],
+      install_requires=['gym']
 )

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
+import setuptools
 from setuptools import setup
 
 setup(name='gym_RLcourse',
       author='Ayca Özcelikkale',
       url='https://github.com/ozayca/gym-RLcourse',
-      packages=["gym_RLcourse"],
+      packages=setuptools.find_packages(),
       install_requires=['gym']
 )


### PR DESCRIPTION
Hej!

This PR fixes some installation problems that I had on my computer and on Google Colab, similar to https://github.com/andremht/gym-gridworld/pull/1 (I didn't add a description since the repo does not have one).

~~Interestingly, `packages = setuptools.find_packages()` was not sufficient since apparently it did not find the "gym_RLcourse" package (I didn't investigate it further, I was happy that these changes fix my issues :slightly_smiling_face:).~~ Edit: I stand corrected, see comment below.

More specifically, if this PR is merged one can just install the package from within the Jupyter notebook or on Google colab by running a code cell with
```python
%pip install git+https://github.com/ozayca/gym-RLcourse.git
```
(Started doing this when debugging an installation problem that a student faced.)

Until this PR is merged one can use the branch with these fixes in my fork and run instead
```python
%pip install git+https://github.com/devmotion/gym-RLcourse.git@dw/setup_py
```